### PR TITLE
Bump sqlx version to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-type"
-version = "0.3.11"
+version = "0.3.12"
 authors = ["Jakob Truelsen <antialize@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -14,6 +14,6 @@ description = "Typed sql macros for sqlx"
 members = ["sqlx-type-macro", "."]
 
 [dependencies]
-sqlx = { version = "0.6", default-features = false, features = [ "mysql", "chrono", "runtime-tokio-native-tls" ]}
+sqlx = { version = "0.7", default-features = false, features = [ "mysql", "chrono", "runtime-tokio-native-tls" ]}
 sqlx-type-macro = { version = "0.3.10", path = "./sqlx-type-macro"}
 chrono = "0.4"


### PR DESCRIPTION
It seems like none of the breaking changes from upstream affected this package: https://github.com/launchbadge/sqlx/blob/main/CHANGELOG.md#070---2023-06-30

I did not find any issues when I compiled rustweb with sqlx-type version 0.3.12